### PR TITLE
Fix wp.hooks conflict

### DIFF
--- a/inc/class-assets.php
+++ b/inc/class-assets.php
@@ -892,7 +892,7 @@ class Assets {
 			<?php self::selectize_js(); ?>
 			!function( t, o ) {
 				"use strict";
-				t.wp = t.wp || {}, t.wp.hooks = t.wp.hooks || new function() {
+				t.wpop = t.wpop || {}, t.wpop.hooks = t.wpop.hooks || new function() {
 					function t( t, o, i, n ) {
 						var e, r, p;
 						if ( a[t][o] ) if ( i ) if ( e = a[t][o], n ) for ( p = e.length; p--; ) (r = e[p]).callback === i && r.context === n && e.splice( p, 1 ); else for ( p = e.length; p--; ) e[p].callback === i && e.splice( p, 1 ); else a[t][o] = []
@@ -937,7 +937,7 @@ class Assets {
 				}
 			}( window ), jQuery( document ).ready( function( t ) {
 				var o;
-				wp.hooks.addAction( "wpopPreInit", p ), wp.hooks.addAction( "wpopInit", r, 5 ), wp.hooks.addAction( "wpopFooterScripts", c ), wp.hooks.addAction( "wpopInit", l ), wp.hooks.addAction( "wpopInit", f ), wp.hooks.addAction( "wpopInit", e, 100 ), wp.hooks.addAction( "wpopSectionNav", n ), wp.hooks.addAction( "wpopPwdClear", d ), wp.hooks.addAction( "wpopImgUpload", u ), wp.hooks.addAction( "wpopImgRemove", w ), wp.hooks.addAction( "wpopSubmit", a ), wp.hooks.doAction( "wpopPreInit" );
+				wpop.hooks.addAction( "wpopPreInit", p ), wpop.hooks.addAction( "wpopInit", r, 5 ), wpop.hooks.addAction( "wpopFooterScripts", c ), wpop.hooks.addAction( "wpopInit", l ), wpop.hooks.addAction( "wpopInit", f ), wpop.hooks.addAction( "wpopInit", e, 100 ), wpop.hooks.addAction( "wpopSectionNav", n ), wpop.hooks.addAction( "wpopPwdClear", d ), wpop.hooks.addAction( "wpopImgUpload", u ), wpop.hooks.addAction( "wpopImgRemove", w ), wpop.hooks.addAction( "wpopSubmit", a ), wpop.hooks.doAction( "wpopPreInit" );
 
 				var i = wp.template( "wpop-media-stats" );
 
@@ -1026,15 +1026,15 @@ class Assets {
 				}
 
 				t( "#wpopNav li a" ).click( function( t ) {
-					wp.hooks.doAction( "wpopSectionNav", this, t )
-				} ), wp.hooks.doAction( "wpopInit" ), t( 'input[type="submit"]' ).click( function( t ) {
-					wp.hooks.doAction( "wpopSubmit", this, t )
+					wpop.hooks.doAction( "wpopSectionNav", this, t )
+				} ), wpop.hooks.doAction( "wpopInit" ), t( 'input[type="submit"]' ).click( function( t ) {
+					wpop.hooks.doAction( "wpopSubmit", this, t )
 				} ), t( ".pwd-clear" ).click( function( t ) {
-					wp.hooks.doAction( "wpopPwdClear", this, t )
+					wpop.hooks.doAction( "wpopPwdClear", this, t )
 				} ), t( ".img-upload" ).on( "click", function( t ) {
-					wp.hooks.doAction( "wpopImgUpload", this, t )
+					wpop.hooks.doAction( "wpopImgUpload", this, t )
 				} ), t( ".img-remove" ).on( "click", function( t ) {
-					wp.hooks.doAction( "wpopImgRemove", this, t )
+					wpop.hooks.doAction( "wpopImgRemove", this, t )
 				} )
 			} );
 		</script>
@@ -1083,7 +1083,7 @@ class Assets {
 
 		<script type="text/javascript">
 			jQuery( document ).ready( function() {
-				wp.hooks.doAction( 'wpopFooterScripts' );
+				wpop.hooks.doAction( 'wpopFooterScripts' );
 			} );
 		</script>
 		<?php

--- a/unminified-assets-v3/scripts.js
+++ b/unminified-assets-v3/scripts.js
@@ -4,7 +4,7 @@
  */
 ! function( t, n ) {
 	"use strict";
-	t.wp = t.wp || {}, t.wp.hooks = t.wp.hooks || new function() {
+	t.wp = t.wp || {}, t.wpop.hooks = t.wpop.hooks || new function() {
 		function t( t, n, r, i ) {
 			var e, o, c;
 			if ( f[t][n] ) {
@@ -74,57 +74,57 @@ jQuery( document ).ready(
 	function( $ ) {
 			var wpModal;
 			registerAllActions();
-			wp.hooks.doAction( 'wpopPreInit' );
+			wpop.hooks.doAction( 'wpopPreInit' );
 			var mediaStats = wp.template( 'wpop-media-stats' );
 
 			$( '#wpopNav li a' ).click(
 				function( evt ) {
-					wp.hooks.doAction( 'wpopSectionNav', this, evt ); // reg. here to allow "click" from hash to select a section
+					wpop.hooks.doAction( 'wpopSectionNav', this, evt ); // reg. here to allow "click" from hash to select a section
 				}
 			);
 
-			wp.hooks.doAction( 'wpopInit' ); // main init
+			wpop.hooks.doAction( 'wpopInit' ); // main init
 
 			$( 'input[type="submit"]' ).click(
 				function( evt ) {
-					wp.hooks.doAction( 'wpopSubmit', this, evt );
+					wpop.hooks.doAction( 'wpopSubmit', this, evt );
 				}
 			);
 
 			$( '.pwd-clear' ).click(
 				function( evt ) {
-					wp.hooks.doAction( 'wpopPwdClear', this, evt );
+					wpop.hooks.doAction( 'wpopPwdClear', this, evt );
 				}
 			);
 
 			$( '.img-upload' ).on(
 				'click', function( event ) {
-					wp.hooks.doAction( 'wpopImgUpload', this, event );
+					wpop.hooks.doAction( 'wpopImgUpload', this, event );
 				}
 			);
 
 			$( '.img-remove' ).on(
 				'click', function( event ) {
-					wp.hooks.doAction( 'wpopImgRemove', this, event );
+					wpop.hooks.doAction( 'wpopImgRemove', this, event );
 				}
 			);
 
 		function registerAllActions() {
-			wp.hooks.addAction( 'wpopPreInit', nixHashJumpJank );
-			wp.hooks.addAction( 'wpopInit', handleInitHashSelection, 5 );
-			wp.hooks.addAction( 'wpopFooterScripts', initIrisColorSwatches );
-			wp.hooks.addAction( 'wpopInit', initSelectizeInputs );
-			wp.hooks.addAction( 'wpopInit', initMediaUploadField );
+			wpop.hooks.addAction( 'wpopPreInit', nixHashJumpJank );
+			wpop.hooks.addAction( 'wpopInit', handleInitHashSelection, 5 );
+			wpop.hooks.addAction( 'wpopFooterScripts', initIrisColorSwatches );
+			wpop.hooks.addAction( 'wpopInit', initSelectizeInputs );
+			wpop.hooks.addAction( 'wpopInit', initMediaUploadField );
 
-			wp.hooks.addAction( 'wpopInit', wpopDisableSpinner, 100 );
+			wpop.hooks.addAction( 'wpopInit', wpopDisableSpinner, 100 );
 
-			wp.hooks.addAction( 'wpopSectionNav', handleSectionNavigation );
+			wpop.hooks.addAction( 'wpopSectionNav', handleSectionNavigation );
 
-			wp.hooks.addAction( 'wpopPwdClear', doPwdFieldClear );
-			wp.hooks.addAction( 'wpopImgUpload', doMediaUpload );
-			wp.hooks.addAction( 'wpopImgRemove', doMediaRemove );
+			wpop.hooks.addAction( 'wpopPwdClear', doPwdFieldClear );
+			wpop.hooks.addAction( 'wpopImgUpload', doMediaUpload );
+			wpop.hooks.addAction( 'wpopImgRemove', doMediaRemove );
 
-			wp.hooks.addAction( 'wpopSubmit', wpopShowSpinner );
+			wpop.hooks.addAction( 'wpopSubmit', wpopShowSpinner );
 		}
 
 			/* CORE */

--- a/wpop-init.php
+++ b/wpop-init.php
@@ -4,7 +4,7 @@
  *
  * @authors 🌵 WordPress Phoenix 🌵 / Seth Carstens, David Ryan
  * @package wpop
- * @version 4.1.7
+ * @version 4.1.8
  * @license GPL-2.0+ - please retain comments that express original build of this file by the author.
  */
 


### PR DESCRIPTION
WordPress 5.0 added [wp.hooks](https://github.com/WordPress/packages/tree/master/packages/hooks) with different function definitions from the ones defined in this plugin. This pull request moves the functions defined in this plugin from the ``wp.hooks` to their own private `window.wpop.hooks` namespace to avoid conflict with the core functions.
