### PR TITLE
Support manual asset paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "config": {
-	"sort-packages": true
+    "sort-packages": true
   },
   "require-dev": {
     "automattic/vipwpcs": "^0.4.0",

--- a/src/class-wordpress-options-panels.php
+++ b/src/class-wordpress-options-panels.php
@@ -35,12 +35,21 @@ class WordPress_Options_Panels {
 	 * @param string $plugins_installed_dir Install directory of the plugin.
 	 * @param string $plugins_installed_url Install plugin URL.
 	 * @param string $plugin_basedir        Base plugin directory.
+	 * @param string $asset_dir_url         A direct URL path to the static assets.
 	 */
-	public function __construct( $plugins_installed_dir, $plugins_installed_url, $plugin_basedir ) {
-		$current_dir         = dirname( __FILE__ );
-		$relative_dir        = str_replace( $plugin_basedir . '/', '', $current_dir );
+	public function __construct(
+		$plugins_installed_dir,
+		$plugins_installed_url,
+		$plugin_basedir,
+		$asset_dir_url = null
+	) {
+		$current_dir  = dirname( __FILE__ );
+		$relative_dir = str_replace( $plugin_basedir . '/', '', $current_dir );
+
 		$this->installed_dir = $plugin_basedir . '/' . $relative_dir;
 		$this->installed_url = $plugins_installed_url . $relative_dir;
+		$this->asset_dir_url = $asset_dir_url;
+
 		// Data api wrappers.
 		foreach ( glob( trailingslashit( dirname( __FILE__ ) ) . 'inc/api/class-*.php' ) as $file ) {
 			include_once $file;
@@ -81,8 +90,14 @@ class WordPress_Options_Panels {
 	 * @return \WPOP\V_5_0\Page
 	 */
 	public function register_page( $options_page_slug, $options_page_type, $parent_menu_id = null ) {
-
-		return new Page( $options_page_slug, $options_page_type, $parent_menu_id, $this->installed_dir, $this->installed_url );
+		return new Page(
+			$options_page_slug,
+			$options_page_type,
+			$parent_menu_id,
+			$this->installed_dir,
+			$this->installed_url,
+			$this->asset_dir_url
+		);
 	}
 
 }

--- a/src/inc/class-page.php
+++ b/src/inc/class-page.php
@@ -132,13 +132,22 @@ class Page {
 	 * @param string|null $parent_menu_id    The parent id only set if this is a sub_menu.
 	 * @param string      $installed_dir     A field value of menu slug.
 	 * @param string      $installed_dir_uri A value of either main_menu or sub_menu.
+	 * @param string      $asset_dir_url     A direct path to static assets.
 	 */
-	public function __construct( $options_page_slug, $options_page_type, $parent_menu_id, $installed_dir, $installed_dir_uri ) {
+	public function __construct(
+		$options_page_slug,
+		$options_page_type,
+		$parent_menu_id,
+		$installed_dir,
+		$installed_dir_uri,
+		$asset_dir_url = null
+	) {
 		$this->slug              = $options_page_slug;
 		$this->type              = $options_page_type;
 		$this->parent_menu_id    = $parent_menu_id;
 		$this->installed_dir     = $installed_dir;
 		$this->installed_dir_uri = $installed_dir_uri;
+		$this->asset_dir_url     = $asset_dir_url;
 	}
 
 	/**
@@ -239,16 +248,19 @@ class Page {
 	 * @return void
 	 */
 	public function maybe_run_footer_scripts( $screen ) {
-		$flag1 = stristr( $screen->id, $this->slug );
-		$flag2 = $this->installed_dir_uri;
-		if ( false === stristr( $screen->id, $this->slug ) || null === $this->installed_dir_uri ) {
+		if ( false === stristr( $screen->id, $this->slug ) ) {
+			return;
+		}
+
+		// Either asset_dir_url or installed_dir_uri must be set.
+		if ( null === $this->asset_dir_url || null === $this->installed_dir_uri ) {
 			return;
 		}
 
 		$asset_class_path = __NAMESPACE__ . '\\Assets';
 
 		// Instantiate the Asset class with the installed directory as a parameter.
-		$asset_class = new $asset_class_path( $this->installed_dir_uri );
+		$asset_class = new $asset_class_path( $this->asset_dir_url ?? $this->installed_dir_uri );
 
 		add_action(
 			'admin_print_footer_scripts-' . $screen->id,

--- a/src/inc/class-page.php
+++ b/src/inc/class-page.php
@@ -259,6 +259,10 @@ class Page {
 
 		$asset_class_path = __NAMESPACE__ . '\\Assets';
 
+		if ( null !== $this->asset_dir_url ) {
+			$this->asset_dir_url = $this->asset_dir_url . '/wordpress-phoenix/wordpress-options-builder-class/src';
+		}
+
 		// Instantiate the Asset class with the installed directory as a parameter.
 		$asset_class = new $asset_class_path( $this->asset_dir_url ?? $this->installed_dir_uri );
 

--- a/src/inc/page-parts/class-assets.php
+++ b/src/inc/page-parts/class-assets.php
@@ -12,6 +12,7 @@ namespace WPOP\V_5_0;
  * Class Assets
  */
 class Assets {
+
 	/**
 	 * Installed Directory URI
 	 *
@@ -199,4 +200,5 @@ class Assets {
 		</script>
 		<?php
 	}
+
 }


### PR DESCRIPTION
Due to the "autoloading" process, sometimes it may be impossible to calculate asset paths from the installed dir/URI.

If multiple plugins load their own copies of the library, `class_exists` checks will only allow the first instance to be `require`d. This breaks the automatic directory detection because the plugin `dirname( __FILE__ )` does not cleanly diff with the library's `dirname( __FILE__ )`.

As a patch, this PR provides an alternate "override" option where you can set the specific URL path to the Composer lib directory.

E.g.:

```php
// Initialize the site options class.
$this->site_options = new WordPress_Options_Panels(
	$installed_dir,
	$installed_url,
	$plugins_dir,
	'/wp-content/plugins/my-custom-plugin/lib'
);
```

If not provided, the parameter will be `null` and the library will use the default behavior.