### PR TITLE
Coding Standards Issue

### DIFF
--- a/src/class-wordpress-options-panels.php
+++ b/src/class-wordpress-options-panels.php
@@ -4,7 +4,7 @@
  *
  * @authors 🌵 WordPress Phoenix 🌵 / Seth Carstens, David Ryan
  * @package wpop
- * @version 5.0.3
+ * @version 5.0.4
  * @license GPL-2.0+ - please retain comments that express original build of this file by the author.
  */
 

--- a/src/inc/api/class-mcrypt.php
+++ b/src/inc/api/class-mcrypt.php
@@ -84,7 +84,7 @@ class Mcrypt {
 	 * @return string
 	 */
 	public static function mcrypt_decrypt( $encrypted_string ) {
-		if ( version_compare( phpversion(), '7.2', '<' ) ) {
+		if ( version_compare( phpversion(), '7.1', '>' ) ) {
 			return new \WP_Error( 'php_version', __( 'PHP version is to low to support mcrypt_decrypt. This function has been DEPRECATED as of PHP 7.1.0 and REMOVED as of PHP 7.2.0. Relying on this function is highly discouraged.', 'wpop' ) );
 		}
 

--- a/src/inc/api/class-mcrypt.php
+++ b/src/inc/api/class-mcrypt.php
@@ -84,7 +84,7 @@ class Mcrypt {
 	 * @return string
 	 */
 	public static function mcrypt_decrypt( $encrypted_string ) {
-		if ( version_compare( phpversion(), '7.1', '>' ) ) {
+		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
 			return new \WP_Error( 'php_version', __( 'PHP version is to low to support mcrypt_decrypt. This function has been DEPRECATED as of PHP 7.1.0 and REMOVED as of PHP 7.2.0. Relying on this function is highly discouraged.', 'wpop' ) );
 		}
 

--- a/src/inc/api/class-mcrypt.php
+++ b/src/inc/api/class-mcrypt.php
@@ -84,6 +84,12 @@ class Mcrypt {
 	 * @return string
 	 */
 	public static function mcrypt_decrypt( $encrypted_string ) {
+		if ( version_compare( phpversion(), '7.2', '<' ) ) {
+			return new \WP_Error( 'php_version', __( 'PHP version is to low to support mcrypt_decrypt. This function has been DEPRECATED as of PHP 7.1.0 and REMOVED as of PHP 7.2.0. Relying on this function is highly discouraged.', 'wpop' ) );
+		}
+
+		// Throws errors depending on version of PHP. Added the catch above to account for this.
+		// @codingStandardsIgnoreStart
 		return trim(
 			mcrypt_decrypt(
 				MCRYPT_RIJNDAEL_256,
@@ -92,6 +98,7 @@ class Mcrypt {
 				MCRYPT_MODE_ECB
 			)
 		);
+		// @codingStandardsIgnoreEnd
 	}
 
 }


### PR DESCRIPTION
The mcrypt_decrypt function has been removed since PHP 7.2. 
This is throwing PHPCS errors. 
Added checks for PHP version and CS ignore.