### PR TITLE
Fixing PHPCompatibilityWP issues for mcrypt_decrypt

### DIFF
--- a/src/class-wordpress-options-panels.php
+++ b/src/class-wordpress-options-panels.php
@@ -4,7 +4,7 @@
  *
  * @authors 🌵 WordPress Phoenix 🌵 / Seth Carstens, David Ryan
  * @package wpop
- * @version 5.0.4
+ * @version 5.0.5
  * @license GPL-2.0+ - please retain comments that express original build of this file by the author.
  */
 

--- a/src/inc/api/class-mcrypt.php
+++ b/src/inc/api/class-mcrypt.php
@@ -58,8 +58,13 @@ class Mcrypt {
 	 * @return string
 	 */
 	public static function upgrade_mcrypt_option( $encrypted_string ) {
+		// mcrypt was removed in PHP 7.2.
+		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
+			return new \WP_Error( 'php_version', __( 'PHP version is to low to support mcrypt_decrypt. This function has been DEPRECATED as of PHP 7.1.0 and REMOVED as of PHP 7.2.0. Relying on this function is highly discouraged.', 'wpop' ) );
+		}
+
 		// If we cannot successfully decrypt, try falling back to mcrypt and re-encrypting.
-		$result = static::mcrypt_decrypt( $encrypted_string );
+		$result = static::mcrypt_decrypt( $encrypted_string ); // @codingStandardsIgnoreLine | // mcrypt was removed in PHP 7.2.
 
 		// Could not decrypt; return nothing.
 		if ( false === $result ) {


### PR DESCRIPTION
Fixing:

```
FILE: ...nix/wordpress-options-builder-class/src/inc/api/class-mcrypt.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 62 | ERROR | Extension 'mcrypt' is deprecated since PHP 7.1 and
    |       | removed since PHP 7.2; Use openssl (preferred) or
    |       | pecl/mcrypt once available instead
----------------------------------------------------------------------
```