### PR TITLE
Fix namespacing and version bump

### DIFF
--- a/src/class-wordpress-options-panels.php
+++ b/src/class-wordpress-options-panels.php
@@ -4,7 +4,7 @@
  *
  * @authors 🌵 WordPress Phoenix 🌵 / Seth Carstens, David Ryan
  * @package wpop
- * @version 5.0.5
+ * @version 5.0.6
  * @license GPL-2.0+ - please retain comments that express original build of this file by the author.
  */
 

--- a/src/inc/api/class-mcrypt.php
+++ b/src/inc/api/class-mcrypt.php
@@ -11,7 +11,7 @@ namespace WPOP\V_5_0;
 /**
  * Class Mcrypt
  *
- * @package WPOP\V_4_0
+ * @package WPOP\V_5_0
  */
 class Mcrypt {
 
@@ -72,7 +72,7 @@ class Mcrypt {
 		}
 
 		// Re-encrypt with OpenSSL.
-		Password::encrypt( $result );
+		Fields\Password::encrypt( $result );
 
 		return $result;
 	}


### PR DESCRIPTION
Correct the namespacing in mcrypt file 
Passwords class was moved inside Fields in v5
