### PR TITLE
Version Bump

### DIFF
--- a/src/class-wordpress-options-panels.php
+++ b/src/class-wordpress-options-panels.php
@@ -4,7 +4,7 @@
  *
  * @authors 🌵 WordPress Phoenix 🌵 / Seth Carstens, David Ryan
  * @package wpop
- * @version 5.0.6
+ * @version 5.1.1
  * @license GPL-2.0+ - please retain comments that express original build of this file by the author.
  */
 


### PR DESCRIPTION
Fix versioning for SemVer practice
There was an earlier release at 5.1.0
Then somehow the next versions after that went back down to 5.0.x
Putting the latest version up to 5.1.x